### PR TITLE
addition includes for windows; add path argument to root()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required(VERSION 3.12)
+project(zipper)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+
+set(
+    ZLIB_COMPAT ON
+    ZLIB_ENABLE_TESTS OFF
+)
+add_subdirectory(external/zlib-ng)
+
+set(USE_AES ON)
+add_subdirectory(external/minizip)
+target_include_directories(minizip PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/external/zlib-ng>
+)
+add_library(zipper STATIC 
+    src/utils/Path.cpp
+    src/utils/Timestamp.cpp
+    src/Zipper.cpp
+    src/Unzipper.cpp
+)
+
+if(WIN32)
+target_sources(zipper PRIVATE
+    src/utils/dirent.c
+)
+target_compile_definitions(zipper PRIVATE
+    USE_WINDOWS=ON
+    NOMINMAX=ON
+)
+endif()
+
+target_include_directories(zipper PRIVATE 
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    src
+    external/minizip
+)
+
+target_include_directories(zipper PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+target_link_libraries(zipper PRIVATE
+    minizip
+    zlibstatic
+)

--- a/src/Unzipper.cpp
+++ b/src/Unzipper.cpp
@@ -18,8 +18,7 @@
 #include <stdexcept>
 #include <iostream>
 #if defined(USE_WINDOWS)
-    #include "external/minizip/ioapi.h"
-    #include "external/minizip/iowin32.h"
+    #include "utils/OS.hpp"
 #else
     #include <utime.h>
 #endif

--- a/src/Unzipper.cpp
+++ b/src/Unzipper.cpp
@@ -17,7 +17,12 @@
 #include <fstream>
 #include <stdexcept>
 #include <iostream>
-#include <utime.h>
+#if defined(USE_WINDOWS)
+    #include "external/minizip/ioapi.h"
+    #include "external/minizip/iowin32.h"
+#else
+    #include <utime.h>
+#endif
 #include <array>
 
 #ifndef ZIPPER_WRITE_BUFFER_SIZE
@@ -28,7 +33,7 @@ namespace zipper {
 
 enum class unzipper_error
 {
-    NO_ERROR = 0,
+    NO_ERROR_UNZIPPER = 0,
     //! Error when accessing to a info entry
     NO_ENTRY,
     //! Error inside libraries
@@ -57,7 +62,7 @@ struct UnzipperErrorCategory : std::error_category
 
         switch (static_cast<unzipper_error>(ev))
         {
-        case unzipper_error::NO_ERROR:
+        case unzipper_error::NO_ERROR_UNZIPPER:
             return "There was no error";
         case unzipper_error::NO_ENTRY:
             return "Error, couldn't get the current entry info";

--- a/src/Zipper.cpp
+++ b/src/Zipper.cpp
@@ -8,10 +8,7 @@
 #include "Zipper/Zipper.hpp"
 #include "external/minizip/zip.h"
 #include "external/minizip/ioapi_mem.h"
-#if defined(USE_WINDOWS)
-    #include "external/minizip/ioapi.h"
-    #include "external/minizip/iowin32.h"
-#endif
+#include "utils/OS.hpp"
 #include "utils/Path.hpp"
 #include "utils/Timestamp.hpp"
 

--- a/src/Zipper.cpp
+++ b/src/Zipper.cpp
@@ -8,6 +8,10 @@
 #include "Zipper/Zipper.hpp"
 #include "external/minizip/zip.h"
 #include "external/minizip/ioapi_mem.h"
+#if defined(USE_WINDOWS)
+    #include "external/minizip/ioapi.h"
+    #include "external/minizip/iowin32.h"
+#endif
 #include "utils/Path.hpp"
 #include "utils/Timestamp.hpp"
 
@@ -22,7 +26,7 @@ namespace zipper {
 
 enum class zipper_error
 {
-    NO_ERROR = 0,
+    NO_ERROR_ZIPPER = 0,
     OPENING_ERROR,
     INTERNAL_ERROR,
     NO_ENTRY,
@@ -48,7 +52,7 @@ struct ZipperErrorCategory : std::error_category
 
         switch (static_cast<zipper_error>(ev))
         {
-        case zipper_error::NO_ERROR:
+        case zipper_error::NO_ERROR_ZIPPER:
             return "There was no error";
         case zipper_error::OPENING_ERROR:
             return "Opening error";

--- a/src/utils/Path.cpp
+++ b/src/utils/Path.cpp
@@ -143,7 +143,7 @@ bool Path::isRoot(const std::string& path)
 }
 
 // -----------------------------------------------------------------------------
-std::string Path::root()
+std::string Path::root(const std::string& path)
 {
 #ifdef _WIN32
     // Check if we have an absolute path with drive,
@@ -178,11 +178,11 @@ std::string Path::dirName(const std::string& path)
     {
         // Single = intended
         if (pos == 0) // /usr
-            return root();
+            return root(path);
 
 #ifdef _WIN32
         if ((pos == 1) && path[1] == ':') // X:/foo
-            return root();
+            return root(path);
 #endif
         // regular/path or /regular/path
         return path.substr(0, pos);

--- a/src/utils/Path.cpp
+++ b/src/utils/Path.cpp
@@ -154,6 +154,7 @@ std::string Path::root(const std::string& path)
     else
         return DIRECTORY_SEPARATOR;
 #else
+    (void) path;
     return DIRECTORY_SEPARATOR;
 #endif
 }

--- a/src/utils/Path.hpp
+++ b/src/utils/Path.hpp
@@ -34,7 +34,7 @@ public:
     static const std::string Separator;
 
     //! \brief
-    static std::string root();
+    static std::string root(const std::string& path);
     static bool isRoot(const std::string& path);
 
     //! \brief


### PR DESCRIPTION
* `Path::root()` is using a path argument if `USE_WINDOWS` is defined
* `NO_ERROR` in enums `zipper_error` and `unzipper_error` need to be renamed to avoid conflict with `NO_ERROR` macro when Windows.h is included
* additional minizip includes were necessary for windows builds
* added CMakeLists to build zlib-ng, minizip and zipper

resolves https://github.com/Lecrapouille/zipper/issues/4