### PR TITLE
build shared library with cmake

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -152,20 +152,19 @@ jobs:
           cd build
           cmake .. -DZIPPER_BUILD_DEMOS=ON -DZIPPER_BUILD_TESTS=ON
           cmake --build . --config Release
-          Test-Path -Path .\Release\zipper.lib
-          Test-Path -Path .\Release\zipper.dll
+          Test-Path -Path ".\Release\zipper.lib"
       - name: Install and verify files
         shell: powershell
         run: |
-          cmake --install . --config Release
-#          # Check static and shared libraries
-#          Test-Path -Path "C:\Program Files\zipper\lib\zipper.lib"
-#          Test-Path -Path "C:\Program Files\zipper\bin\zipper.dll"
-#          # Check pkg-config file
-#          Test-Path -Path "C:\Program Files\zipper\lib\pkgconfig\zipper.pc"
-#          # Check headers
-#          Test-Path -Path "C:\Program Files\zipper\include\Zipper\Zipper.hpp"
-#          Test-Path -Path "C:\Program Files\zipper\include\Zipper\Unzipper.hpp"
+          cmake --install build --prefix "C:\Program Files\zipper"
+          # Check static and shared libraries
+          Test-Path -Path "C:\Program Files\zipper\lib\zipper.lib"
+          # Check pkg-config file
+          Test-Path -Path "C:\Program Files\zipper\lib\pkgconfig\zipper.pc"
+          # Check headers
+          Test-Path -Path "C:\Program Files\zipper\include\Zipper\Zipper.hpp"
+          Test-Path -Path "C:\Program Files\zipper\include\Zipper\Unzipper.hpp"
+          Test-Path -Path "C:\Program Files\zipper\include\zipper_export.h"
 #      - name: Non regression
 #        shell: powershell
 #        run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,6 @@ endif()
 option(USE_AES "Enable AES encryption" ON)
 add_subdirectory(external/minizip)
 target_include_directories(minizip PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/external/zlib-ng>
 )
 
@@ -74,10 +73,11 @@ function(configure_zipper_target target)
         src
         external/minizip
     )
-
+        
     # Public include directories
     target_include_directories(${target} PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/include
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     )
 
     # Library dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@
 cmake_minimum_required(VERSION 3.12)
 project(zipper VERSION 2.2.0)
 
+include(GenerateExportHeader)
+
 ##############################################################################
 # Global compiler settings
 ##############################################################################
@@ -18,7 +20,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 ##############################################################################
 option(ZIPPER_BUILD_DEMOS "Build the demo applications" OFF)
 option(ZIPPER_BUILD_TESTS "Build the test applications" OFF)
-
+option(ZIPPER_SHARED_LIB "Build zipper as a shared library" OFF)
 ##############################################################################
 # External dependencies
 ##############################################################################
@@ -35,6 +37,7 @@ endif()
 option(USE_AES "Enable AES encryption" ON)
 add_subdirectory(external/minizip)
 target_include_directories(minizip PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/external/zlib-ng>
 )
 
@@ -84,22 +87,19 @@ function(configure_zipper_target target)
     )
 endfunction()
 
-# Static library
-add_library(zipper STATIC ${ZIPPER_SOURCES})
+if(ZIPPER_SHARED_LIB)
+    set(LIBRARY_TYPE SHARED)
+else()
+    set(LIBRARY_TYPE STATIC)
+endif()
+
+# Static or shared library
+add_library(zipper ${LIBRARY_TYPE} ${ZIPPER_SOURCES})
 configure_zipper_target(zipper)
 
-# Shared library
-add_library(zipper_shared SHARED ${ZIPPER_SOURCES})
-set_target_properties(zipper_shared PROPERTIES
-    OUTPUT_NAME zipper
-    VERSION 2.0.0
-    SOVERSION 2
-)
-if(WIN32)
-    # FIXME https://github.com/Lecrapouille/zipper/issues/16
-    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-endif()
-configure_zipper_target(zipper_shared)
+generate_export_header(zipper)
+target_compile_definitions(zipper PRIVATE zipper_EXPORTS)
+
 
 ##############################################################################
 # Demo applications
@@ -138,11 +138,14 @@ configure_file(
 
 # Installation rules
 include(GNUInstallDirs)
-install(TARGETS zipper zipper_shared
+install(TARGETS zipper
     EXPORT zipperTargets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/zipper_export.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/zipper.pc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ include(GenerateExportHeader)
 ##############################################################################
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 ##############################################################################

--- a/include/Zipper/Unzipper.hpp
+++ b/include/Zipper/Unzipper.hpp
@@ -15,6 +15,8 @@
 #include <iostream>
 #include <sstream>
 
+#include "zipper_export.h"
+
 namespace zipper {
 
 class ZipEntry;
@@ -22,7 +24,7 @@ class ZipEntry;
 // *****************************************************************************
 //! \brief Zip archive extractor/decompressor.
 // *****************************************************************************
-class Unzipper
+class ZIPPER_EXPORT Unzipper
 {
 public:
 

--- a/include/Zipper/Zipper.hpp
+++ b/include/Zipper/Zipper.hpp
@@ -15,12 +15,14 @@
 #include <ctime>
 #include <system_error>
 
+#include "zipper_export.h"
+
 namespace zipper {
 
 // *************************************************************************
 //! \brief Zip archive compressor.
 // *************************************************************************
-class Zipper
+class ZIPPER_EXPORT Zipper
 {
 public:
 


### PR DESCRIPTION
* use cmake's `generate_export_header` to create zipper_export.h
* removed simultaneous build of static and shared library
* provide config option ZIPPER_SHARED_LIB (default: off) to build as shared library
* add generated header to install

To build zipper as a shared library with cmake
* `mkdir build & cd build`
* `cmake .. -DZIPPER_SHARED_LIB=ON`
* `cmake --build . --config Release`

To install complete package to destination
* `cmake --install . --prefix <path_to_destination>`