### PR TITLE
Wutzig/build test windows static

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,26 +147,48 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Build Zipper with CMake
+      - name: Build Zipper shared with CMake
         shell: powershell
         run: |
-          mkdir build
-          cd build
-          cmake .. -DZIPPER_SHARED_LIB=ON -DZIPPER_BUILD_DEMOS=ON -DZIPPER_BUILD_TESTS=ON
+          mkdir build_shared
+          cd build_shared
+          cmake .. -DZIPPER_SHARED_LIB=ON -DZIPPER_BUILD_DEMOS=ON -DZIPPER_BUILD_TESTS=OFF
+          cmake --build . --config Release
+          Test-Path -Path ".\Release\zipper.dll"
+          Test-Path -Path ".\Release\zipper.lib"
+      - name: Install and verify files
+        shell: powershell
+        run: |
+          cmake --install build_shared --prefix "C:\Program Files\zipper_shared"
+          # Check for shared library files
+          Test-Path -Path "C:\Program Files\zipper_shared\bin\zipper.dll"
+          Test-Path -Path "C:\Program Files\zipper_shared\lib\zipper.lib"
+          # Check pkg-config file
+          Test-Path -Path "C:\Program Files\zipper_shared\lib\pkgconfig\zipper.pc"
+          # Check headers
+          Test-Path -Path "C:\Program Files\zipper_shared\include\Zipper\Zipper.hpp"
+          Test-Path -Path "C:\Program Files\zipper_shared\include\Zipper\Unzipper.hpp"
+          Test-Path -Path "C:\Program Files\zipper_shared\include\zipper_export.h"
+      - name: Build Zipper static with CMake
+        shell: powershell
+        run: |
+          mkdir build_static
+          cd build_static
+          cmake .. -DZIPPER_SHARED_LIB=OFF -DZIPPER_BUILD_DEMOS=ON -DZIPPER_BUILD_TESTS=ON
           cmake --build . --config Release
           Test-Path -Path ".\Release\zipper.dll"
       - name: Install and verify files
         shell: powershell
         run: |
-          cmake --install build --prefix "C:\Program Files\zipper"
-          # Check static and shared libraries
-          Test-Path -Path "C:\Program Files\zipper\lib\zipper.dll"
+          cmake --install build_static --prefix "C:\Program Files\zipper_static"
+          # Check for static library files
+          Test-Path -Path "C:\Program Files\zipper_static\lib\zipper_static.lib"
           # Check pkg-config file
-          Test-Path -Path "C:\Program Files\zipper\lib\pkgconfig\zipper.pc"
+          Test-Path -Path "C:\Program Files\zipper_static\lib\pkgconfig\zipper.pc"
           # Check headers
-          Test-Path -Path "C:\Program Files\zipper\include\Zipper\Zipper.hpp"
-          Test-Path -Path "C:\Program Files\zipper\include\Zipper\Unzipper.hpp"
-          Test-Path -Path "C:\Program Files\zipper\include\zipper_export.h"
+          Test-Path -Path "C:\Program Files\zipper_static\include\Zipper\Zipper.hpp"
+          Test-Path -Path "C:\Program Files\zipper_static\include\Zipper\Unzipper.hpp"
+          Test-Path -Path "C:\Program Files\zipper_static\include\zipper_export.h"
 #      - name: Non regression
 #        shell: powershell
 #        run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -176,19 +176,18 @@ jobs:
           cd build_static
           cmake .. -DZIPPER_SHARED_LIB=OFF -DZIPPER_BUILD_DEMOS=ON -DZIPPER_BUILD_TESTS=ON
           cmake --build . --config Release
-          Test-Path -Path ".\Release\zipper.dll"
+          Test-Path -Path ".\Release\zipper.lib"
       - name: Install and verify files
         shell: powershell
         run: |
           cmake --install build_static --prefix "C:\Program Files\zipper_static"
           # Check for static library files
-          Test-Path -Path "C:\Program Files\zipper_static\lib\zipper_static.lib"
+          Test-Path -Path "C:\Program Files\zipper_static\lib\zipper.lib"
           # Check pkg-config file
           Test-Path -Path "C:\Program Files\zipper_static\lib\pkgconfig\zipper.pc"
           # Check headers
           Test-Path -Path "C:\Program Files\zipper_static\include\Zipper\Zipper.hpp"
           Test-Path -Path "C:\Program Files\zipper_static\include\Zipper\Unzipper.hpp"
-          Test-Path -Path "C:\Program Files\zipper_static\include\zipper_export.h"
 #      - name: Non regression
 #        shell: powershell
 #        run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,22 +69,19 @@ if(WIN32)
         # Prevent Windows' min/max macros from conflicting with std::min/max
         NOMINMAX=ON
     )
-
-    # Windows-specific configurations for DLL support
-    if(ZIPPER_SHARED_LIB)
-        # Include and setup for exporting symbols
-        include(GenerateExportHeader)
-
-        # Generate export header for DLL symbols
-        generate_export_header(zipper
-            BASE_NAME zipper
-            EXPORT_MACRO_NAME ZIPPER_EXPORT
-            EXPORT_FILE_NAME zipper_export.h
-        )
-        target_compile_definitions(zipper PRIVATE zipper_EXPORTS)
-        target_compile_definitions(zipper PUBLIC ZIPPER_EXPORT_DEFINED)
-    endif()
 endif()
+
+# Include and setup for exporting symbols
+include(GenerateExportHeader)
+
+# Generate export header for shared library symbols
+generate_export_header(zipper
+    BASE_NAME zipper
+    EXPORT_MACRO_NAME ZIPPER_EXPORT
+    EXPORT_FILE_NAME zipper_export.h
+)
+target_compile_definitions(zipper PRIVATE zipper_EXPORTS)
+target_compile_definitions(zipper PUBLIC ZIPPER_EXPORT_DEFINED)
 
 # Include directories configuration
 target_include_directories(zipper PRIVATE
@@ -148,14 +145,9 @@ install(TARGETS zipper
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-if(WIN32)
-    #if(ZIPPER_SHARED_LIB)
-        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/zipper_export.h
-            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-        )
-    #endif()
-else()
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/zipper.pc
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
-    )
-endif()
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/zipper_export.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/zipper.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+)

--- a/include/Zipper/Unzipper.hpp
+++ b/include/Zipper/Unzipper.hpp
@@ -21,18 +21,8 @@
 // on Windows.
 // *****************************************************************************
 #if defined(ZIPPER_EXPORT_DEFINED)
-#  if defined(_WIN32)
-#    pragma message("Unzipper: ZIPPER_EXPORT_DEFINED is defined")
-#  else
-#    warning "Unzipper: ZIPPER_EXPORT_DEFINED is not defined"
-#  endif
 #  include "zipper_export.h"
 #else
-#  if defined(_WIN32)
-#    pragma message("Unzipper: ZIPPER_EXPORT_DEFINED is not defined")
-#  else
-#    warning "Unzipper: ZIPPER_EXPORT_DEFINED is not defined"
-#  endif
 #  define ZIPPER_EXPORT
 #endif
 

--- a/include/Zipper/Zipper.hpp
+++ b/include/Zipper/Zipper.hpp
@@ -21,18 +21,8 @@
 // on Windows.
 // *****************************************************************************
 #if defined(ZIPPER_EXPORT_DEFINED)
-#  if defined(_WIN32)
-#    pragma message("Zipper: ZIPPER_EXPORT_DEFINED is defined")
-#  else
-#    warning "Zipper: ZIPPER_EXPORT_DEFINED is not defined"
-#  endif
 #  include "zipper_export.h"
 #else
-#  if defined(_WIN32)
-#    pragma message("Zipper: ZIPPER_EXPORT_DEFINED is not defined")
-#  else
-#    warning "Zipper: ZIPPER_EXPORT_DEFINED is not defined"
-#  endif
 #  define ZIPPER_EXPORT
 #endif
 


### PR DESCRIPTION
* in workflow build both static and shared libs on windows
    * only build tests for static build (shared builds do not expose `Path` functions

* also include zipper_export.h on linux (if build with cmake) and for static libraries